### PR TITLE
delete method with parameter support #379

### DIFF
--- a/docs/Facebook.fbmd
+++ b/docs/Facebook.fbmd
@@ -295,6 +295,7 @@ $response = $fb->post('/me/feed', ['message' => 'Foo message']);
 ~~~~
 public Facebook\FacebookResponse delete(
   string $endpoint,
+  array $params,
   string|AccessToken|null $accessToken,
   string|null $eTag,
   string|null $graphVersion
@@ -303,10 +304,10 @@ public Facebook\FacebookResponse delete(
 
 Sends a DELETE request to Graph and returns a `Facebook\FacebookResponse`.
 
-The arguments are the same as `get()` above.
+The arguments are the same as `post()` above.
 
 ~~~~
-$response = $fb->delete('/{node-id}');
+$response = $fb->delete('/{node-id}', ['object' => '1234']);
 ~~~~
 </card>
 

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -405,6 +405,7 @@ class Facebook
      * Sends a DELETE request to Graph and returns the result.
      *
      * @param string                  $endpoint
+	 * @param array                   $params
      * @param AccessToken|string|null $accessToken
      * @param string|null             $eTag
      * @param string|null             $graphVersion
@@ -413,12 +414,12 @@ class Facebook
      *
      * @throws FacebookSDKException
      */
-    public function delete($endpoint, $accessToken = null, $eTag = null, $graphVersion = null)
+    public function delete($endpoint, array $params = [], $accessToken = null, $eTag = null, $graphVersion = null)
     {
         return $this->sendRequest(
             'DELETE',
             $endpoint,
-            $params = [],
+            $params,
             $accessToken,
             $eTag,
             $graphVersion


### PR DESCRIPTION
The Graph API supports parameters for DELETE Requests.
For example: Unblocking a user from a page requires a parameter "user"
which the current version of the SDK doesn't implement.

Docs were updated also.